### PR TITLE
fix: make it compile on xcode 16.0+

### DIFF
--- a/Sources/JudoRenderer/Environment/ComponentBindings.swift
+++ b/Sources/JudoRenderer/Environment/ComponentBindings.swift
@@ -34,11 +34,11 @@ extension ComponentBindings {
                 partialResult[element.key] = .component(value)
             case let value as Video:
                 partialResult[element.key] = .video(value)
-            case let value as Expression<String>:
+            case let value as JudoDocument.Expression<String>:
                 partialResult[element.key] = .computed(.text(value))
-            case let value as Expression<Double>:
+            case let value as JudoDocument.Expression<Double>:
                 partialResult[element.key] = .computed(.number(value))
-            case let value as Expression<Bool>:
+            case let value as JudoDocument.Expression<Bool>:
                 partialResult[element.key] = .computed(.boolean(value))
             default:
                 break


### PR DESCRIPTION
In iOS 18, a new foundation struct called `Expression` conflicts with the `JudoDocument.Expression` struct. This commit resolves the ambiguity for the compiler